### PR TITLE
Fix Config Saving Issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,10 @@ impl PlaymateConfig {
     fn save(&self) {
         let config_str = toml::to_string(&self).unwrap();
         let appdata_dir = env::var_os("APPDATA").expect("No APPDATA environment variable?");
-        let config_path = Path::new(&appdata_dir).join("playmate").join("config.toml");
+        let config_path = Path::new(&appdata_dir)
+            .join("playmate")
+            .join("default")
+            .join("config.toml");
         fs::write(config_path, config_str).expect("Error writing config file");
     }
 }
@@ -179,7 +182,6 @@ async fn spotify_auth() -> AuthCodeSpotify {
         token_refreshing: true,
         cache_path: Path::new(&appdata_dir)
             .join("playmate")
-            .join("default")
             .join("token_cache.json"),
         // pagination_chunks: 100,
         ..Default::default()


### PR DESCRIPTION
Due to profiles being half-implemented, the config is read from .../playmate/default/config.toml, but is written to .../playmate/config.toml. The token cache was also being saved in the "playmate/default" profile directory, but since it should be shared across profiles, it should be saved one level up in the "playmate" directory. This commit fixes both issues.